### PR TITLE
Parameterize hard coded URL

### DIFF
--- a/lib/exec_anon.xml
+++ b/lib/exec_anon.xml
@@ -107,7 +107,7 @@
 		<attribute name="sessionId" description="Session Id property."/>
 		<sequential>
 			<!-- Obtain Session Id via Login SOAP service -->
-		    <http url="https://login.salesforce.com/services/Soap/c/30.0" method="POST" failonunexpected="false" entityProperty="loginResponse" statusProperty="loginResponseStatus">
+		    <http url="https://${host}/services/Soap/c/30.0" method="POST" failonunexpected="false" entityProperty="loginResponse" statusProperty="loginResponseStatus">
 		    	<headers>
 		    		<header name="Content-Type" value="text/xml"/>
 		    		<header name="SOAPAction" value="login"/>


### PR DESCRIPTION
Fix issue where execute anonymous wasn't working on sandbox environments due to hard-coded URL